### PR TITLE
bug(854436):preview Sample issues in js getting started flow diagram resolve

### DIFF
--- a/ej2-javascript/code-snippet/diagram/getting-started-cs4/index.js
+++ b/ej2-javascript/code-snippet/diagram/getting-started-cs4/index.js
@@ -18,13 +18,19 @@ var connector = [
     {
         id: 'connector4', sourceID: 'Condition', targetID: 'End', annotations: [{ content: 'No' }],
         type: 'Orthogonal',
-        segments: [{ length: 50, direction: 'Bottom' }]
+        segments: [
+            { type: 'Orthogonal', length: 30, direction: "Right" },
+            { type: 'Orthogonal', length: 300, direction: "Bottom" }
+        ]
     },
     { id: 'connector5', sourceID: 'Print', targetID: 'Increment' },
     {
         id: 'connector6', sourceID: 'Increment', targetID: 'Condition',
         type: 'Orthogonal',
-        segments: [{ length: 50, direction: 'Bottom' }]
+        segments: [
+            { type: 'Orthogonal', length: 30, direction: "Left" },
+            { type: 'Orthogonal', length: 200, direction: "Top" }
+        ]
     }
 ];
 


### PR DESCRIPTION
### Description 

To ensure the getting Started Page works fine in all platforms

### Issues 
- the flow diagram sample in getting started page is updated woringly
- diagram rendered at side and connectors overlapping
### Solution

- Resolved the flow chart sample connector collision and fit To page called.